### PR TITLE
Week one

### DIFF
--- a/count-tracker.sh
+++ b/count-tracker.sh
@@ -19,10 +19,19 @@ do
 done
 shift $((OPTIND -1))
 
-
+COUNT=0
 while [ true ];
 do
-  echo "Products:"
-  curl -k -XGET -u admin:admin  "https://$HOST:9200/_cat/count/bbuy_products";
+  NEW_COUNT=$(curl -ks -X GET -u admin:admin  "https://$HOST:9200/_cat/count/bbuy_products" | awk '{print $3}')
+  echo "Products: $NEW_COUNT"
+  if [ "$COUNT" = "$NEW_COUNT" ]
+  then
+    osascript -e 'tell app "System Events" to display notification "🫡 Finished Indexing!" with title "Finally!"'
+    break
+  else
+    COUNT="$NEW_COUNT"
+  fi
+
   sleep 30;
 done
+

--- a/download-data.sh
+++ b/download-data.sh
@@ -1,4 +1,4 @@
-cd /workspace/datasets
+cd ./downloads
 # TODO: put in validation checks
 #pip install kaggle
 echo "Downloading Kaggle"

--- a/index-data.sh
+++ b/index-data.sh
@@ -5,17 +5,20 @@ usage()
   exit 2
 }
 
-DATASETS_DIR="/workspace/datasets"
-PYTHON_LOC="/workspace/search_engineering"
-WEEK="utilities" #Default indexing is in utilities
-PRODUCTS_JSON_FILE="bbuy_products.json"
+CURRENT_DIR=$(cd "$(dirname "$0")/."; pwd)
+
+DATASETS_DIR="$CURRENT_DIR/downloads"
+WEEK="$CURRENT_DIR/week1" #Default indexing is in utilities
+PRODUCTS_JSON_FILE="$WEEK/bbuy_products.json"
 HOST="localhost"
 INDEX_NAME="bbuy_products"
-LOGS_DIR="/workspace/logs"
+LOGS_DIR="$CURRENT_DIR/logs"
 WORKERS=8
 MAX_DOCS=2000000
 BATCH_SIZE=200
-while getopts ':p:b:k:i:o:g:y:d:m:w:h' c
+REFRESH_INTERVAL=-1
+
+while getopts ':p:b:k:i:o:g:d:m:w:h' c
 do
   case $c in
     b) BATCH_SIZE=$OPTARG ;;
@@ -26,42 +29,44 @@ do
     m) MAX_DOCS=$OPTARG ;;
     o) HOST=$OPTARG ;;
     p) PRODUCTS_JSON_FILE=$OPTARG ;;
+    r) REFRESH_INTERVAL=$OPTARG ;;
     w) WORKERS=$OPTARG ;;
-    y) PYTHON_LOC=$OPTARG ;;
     h) usage ;;
     [?])
       echo "Invalid option: -${OPTARG}"
       usage ;;
   esac
 done
+
 shift $((OPTIND -1))
 
-mkdir $LOGS_DIR
+mkdir -p $LOGS_DIR
 
-cd $PYTHON_LOC || exit
-cd $WEEK || exit
-echo "Running python scripts from $PYTHON_LOC/$WEEK"
-
-#eval "$(pyenv init -)"
-#eval "$(pyenv virtualenv-init -)"
 set -x
 
-#pyenv activate search_eng
-echo "Creating index settings and mappings"
-if [ -f $PRODUCTS_JSON_FILE ]; then
-  echo " Product file: $PRODUCTS_JSON_FILE"
-  curl -k -X PUT -u admin:admin  "https://$HOST:9200/$INDEX_NAME" -H 'Content-Type: application/json' -d "@$PRODUCTS_JSON_FILE"
-  if [ $? -ne 0 ] ; then
-    echo "Failed to create index with settings of $PRODUCTS_JSON_FILE"
-    exit 2
-  fi
+cd $WEEK
 
-  if [ -f index.py ]; then
-    echo "Indexing product data in $DATASETS_DIR/product_data/products and writing logs to $LOGS_DIR/index.log"
-    nohup python index.py -w $WORKERS -m $MAX_DOCS -b $BATCH_SIZE -s "$DATASETS_DIR/product_data/products" -o "$HOST" -i "$INDEX_NAME" > "$LOGS_DIR/index.log" &
+for refresh in "-1" "1s" "60s"; do
+  echo "Deleting Products"
+  curl -sk -X DELETE -u admin:admin https://localhost:9200/bbuy_products
+
+  echo "Creating index settings and mappings"
+  if [ -f $PRODUCTS_JSON_FILE ]; then
+    echo " Product file: $PRODUCTS_JSON_FILE"
+    curl -k -X PUT -u admin:admin  "https://$HOST:9200/$INDEX_NAME" -H 'Content-Type: application/json' -d "@$PRODUCTS_JSON_FILE"
     if [ $? -ne 0 ] ; then
-      echo "Failed to index products"
+      echo "Failed to create index with settings of $PRODUCTS_JSON_FILE"
       exit 2
     fi
+
+    if [ -f index.py ]; then
+      echo "Indexing product data in $DATASETS_DIR/product_data/products and writing logs to $LOGS_DIR/index.log"
+      python index.py -w $WORKERS -r "$refresh" -m $MAX_DOCS -b $BATCH_SIZE -s "$DATASETS_DIR/product_data/products" -o "$HOST" -i "$INDEX_NAME" >> "$LOGS_DIR/index.log" &
+      wait
+      if [ $? -ne 0 ] ; then
+        echo "Failed to index products"
+        exit 2
+      fi
+    fi
   fi
-fi
+done

--- a/week-one.md
+++ b/week-one.md
@@ -1,0 +1,125 @@
+# Week one results
+
+## Level 1, Mappings
+
+Here all as expected:
+- Default mappings are analyzed faster than custom ones
+- More fields require more processing time
+
+All of the runs were done with the following defaults:
+
+```
+Max Docs: 2M
+Batch Size: 200
+Workers: 8
+Refresh Interval: -1
+```
+
+### `bbuy_products_no_map` - shorter field set, without user-defined mapping
+```
+Indexing time: 2.08 minutes
+Total accumulated time: 7.78 minutes
+```
+
+### `bbuy_products` - shorter field set, instructor mapping
+```
+Indexing time: 2.24 minutes
+Total accumulated time: 8.99 minutes
+```
+
+### `bbuy_products_no_map` - full field set, without user-defined mapping
+```
+Indexing time: 2.13 minutes
+Total accumulated time: 8.04 minutes
+```
+
+### `bbuy_products` - full field set, instructor mapping
+```
+Indexing time: 2.27 minutes
+Total accumulated time: 9.20 minutes
+```
+
+## Level 1, Refresh Interval
+
+Here, surprisingly `60s` interval performed better than switching it off with `-1`.
+`1s` is the worst, as expected.
+All of the runs were done with the following defaults:
+
+```
+Max Docs: 2M
+Batch Size: 200
+Workers: 8
+Full field set, with `bbuy_products` mappings
+```
+
+### Refresh interval switched off
+```
+Indexing time: 2.13 minutes
+Total accumulated time: 8.24 minutes
+```
+
+### Default refresh interval, 1s
+```
+Indexing time: 2.27 minutes
+Total accumulated time: 9.28 minutes
+```
+
+### 60s
+```
+Indexing time: 2.10 minutes
+Total accumulated time: 8.06 minutes
+```
+
+## Level 1, Batch Size, Refresh Interval 60s
+
+All of the runs were done with the following defaults:
+```
+Max Docs: 2M
+Batch Size: 200
+Workers: 8
+Refresh Interval: 60s
+Full field set, with `bbuy_products` mappings
+```
+
+### 200
+INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 200 per batch.
+INFO:Done. 1275077 were indexed in 2.0352100041656134 minutes. total accumulated time spent in `bulk` indexing: 7.603266260070571 minutes
+
+### 400
+INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 400 per batch.
+INFO:Done. 1275077 were indexed in 2.022885565966135 minutes. total accumulated time spent in `bulk` indexing: 7.4555092402093575 minutes
+
+### 800
+INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 800 per batch.
+INFO:Done. 1275077 were indexed in 2.013187640267036 minutes. total accumulated time spent in `bulk` indexing: 7.35212853756966 minutes
+
+### 1600
+INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 1600 per batch.
+INFO:Done. 1275077 were indexed in 2.08874557223365 minutes. total accumulated time spent in `bulk` indexing: 7.81045693566557 minutes
+
+### 3200
+INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
+INFO:Done. 1275077 were indexed in 2.0867465250000046 minutes. total accumulated time spent in `bulk` indexing: 7.486287612695014 minutes
+
+### 5000
+INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 5000 per batch.
+INFO:Done. 1275077 were indexed in 2.0712099798663983 minutes. total accumulated time spent in `bulk` indexing: 7.462551590200746 minutes
+
+## Level 1, Workes, Refresh Interval -1
+
+### 8
+INFO:Indexing to bbuy_products with 8 workers, refresh_interval of -1 to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
+INFO:Done. 1275077 were indexed in 2.065828593748544 minutes. total accumulated time spent in `bulk` indexing: 7.498947101092199 minutes
+
+### 16
+INFO:Indexing to bbuy_products with 16 workers, refresh_interval of -1 to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
+INFO:Done. 1275077 were indexed in 2.055382668750826 minutes. total accumulated time spent in `bulk` indexing: 22.339362691701776 minutes
+
+### 32
+INFO:Indexing to bbuy_products with 32 workers, refresh_interval of -1 to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
+INFO:Done. 1275077 were indexed in 2.7611230756990457 minutes. total accumulated time spent in `bulk` indexing: 65.16197838865531 minutes
+
+### 64
+INFO:Indexing to bbuy_products with 64 workers, refresh_interval of -1 to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
+INFO:Done. 1275077 were indexed in 3.1376471444498746 minutes. total accumulated time spent in `bulk` indexing: 156.12936868037988 minutes
+

--- a/week-one.md
+++ b/week-one.md
@@ -91,4 +91,15 @@ Time | 8 | 16 | 32 | 64
 Indexing time (minutes) | 2.07 | 2.06 | 2.76 | 3.14
 Total accumulated time (minutes) | 7.50 | 22.34 | 65.16 | 156.13
 
+## Level 2
+
+As expected, simplifying the query can benefit greatly the speed at the cost of result quality 😅
+
+```
+Baseline: 2.45 minutes
+No fuzziness: 2.04 minutes
+Drop function score: 1.60 minutes
+Only multi-match: 1.41 minutes
+Multi-match name and short description only: 0.95 minutes
+```
 

--- a/week-one.md
+++ b/week-one.md
@@ -52,23 +52,11 @@ Workers: 8
 Full field set, with `bbuy_products` mappings
 ```
 
-### Refresh interval switched off
-```
-Indexing time: 2.13 minutes
-Total accumulated time: 8.24 minutes
-```
+Time | -1 | 1s | 60s
+--- | --- | --- | ---
+Indexing time (minutes) | 2.13 | 2.27 | 2.10
+Total accumulated time (minutes) | 8.24 | 9.28 | 8.06
 
-### Default refresh interval, 1s
-```
-Indexing time: 2.27 minutes
-Total accumulated time: 9.28 minutes
-```
-
-### 60s
-```
-Indexing time: 2.10 minutes
-Total accumulated time: 8.06 minutes
-```
 
 ## Level 1, Batch Size
 
@@ -81,41 +69,11 @@ Refresh Interval: 60s
 Full field set, with `bbuy_products` mappings
 ```
 
-### 200
-```
-Indexing time: 2.03 minutes
-Total accumulated time: 7.60 minutes
-```
+Time | 200 | 400 | 800 | 1600 | 3200 | 5000
+--- | --- | --- | --- | --- | --- | ---
+Indexing time (minutes) | 2.03 | 2.02 | 2.01 | 2.09 | 2.09 | 2.07
+Total accumulated time (minutes) | 7.60 | 7.46 | 7.35 | 7.81 | 7.49 | 7.46
 
-### 400
-```
-Indexing time: 2.02 minutes
-Total accumulated time: 7.46 minutes
-```
-
-### 800
-```
-Indexing time: 2.01 minutes
-Total accumulated time: 7.35 minutes
-```
-
-### 1600
-```
-Indexing time: 2.09 minutes
-Total accumulated time: 7.81 minutes
-```
-
-### 3200
-```
-Indexing time: 2.09 minutes
-Total accumulated time: 7.49 minutes
-```
-
-### 5000
-```
-Indexing time: 2.07 minutes
-Total accumulated time: 7.46 minutes
-```
 
 ## Level 1, Workers
 
@@ -128,27 +86,9 @@ Refresh Interval: -1
 Full field set, with `bbuy_products` mappings
 ```
 
-### 8
-```
-Indexing time: 2.07 minutes
-Total accumulated time: 7.50 minutes
-```
+Time | 8 | 16 | 32 | 64
+--- | --- | --- | --- | ---
+Indexing time (minutes) | 2.07 | 2.06 | 2.76 | 3.14
+Total accumulated time (minutes) | 7.50 | 22.34 | 65.16 | 156.13
 
-### 16
-```
-Indexing time: 2.06 minutes
-Total accumulated time: 22.34 minutes
-```
-
-### 32
-```
-Indexing time: 2.76 minutes
-Total accumulated time: 65.16 minutes
-```
-
-### 64
-```
-Indexing time: 3.14 minutes
-Total accumulated time: 156.13 minutes
-```
 

--- a/week-one.md
+++ b/week-one.md
@@ -70,56 +70,85 @@ Indexing time: 2.10 minutes
 Total accumulated time: 8.06 minutes
 ```
 
-## Level 1, Batch Size, Refresh Interval 60s
+## Level 1, Batch Size
 
+The best results were at the batch size of 800. At 1600 and 3200 it gets worse. And at 5000 it gets better again, but not as good as 800.
 All of the runs were done with the following defaults:
 ```
 Max Docs: 2M
-Batch Size: 200
 Workers: 8
 Refresh Interval: 60s
 Full field set, with `bbuy_products` mappings
 ```
 
 ### 200
-INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 200 per batch.
-INFO:Done. 1275077 were indexed in 2.0352100041656134 minutes. total accumulated time spent in `bulk` indexing: 7.603266260070571 minutes
+```
+Indexing time: 2.03 minutes
+Total accumulated time: 7.60 minutes
+```
 
 ### 400
-INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 400 per batch.
-INFO:Done. 1275077 were indexed in 2.022885565966135 minutes. total accumulated time spent in `bulk` indexing: 7.4555092402093575 minutes
+```
+Indexing time: 2.02 minutes
+Total accumulated time: 7.46 minutes
+```
 
 ### 800
-INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 800 per batch.
-INFO:Done. 1275077 were indexed in 2.013187640267036 minutes. total accumulated time spent in `bulk` indexing: 7.35212853756966 minutes
+```
+Indexing time: 2.01 minutes
+Total accumulated time: 7.35 minutes
+```
 
 ### 1600
-INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 1600 per batch.
-INFO:Done. 1275077 were indexed in 2.08874557223365 minutes. total accumulated time spent in `bulk` indexing: 7.81045693566557 minutes
+```
+Indexing time: 2.09 minutes
+Total accumulated time: 7.81 minutes
+```
 
 ### 3200
-INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
-INFO:Done. 1275077 were indexed in 2.0867465250000046 minutes. total accumulated time spent in `bulk` indexing: 7.486287612695014 minutes
+```
+Indexing time: 2.09 minutes
+Total accumulated time: 7.49 minutes
+```
 
 ### 5000
-INFO:Indexing to bbuy_products with 8 workers, refresh_interval of 60s to host localhost with a maximum number of docs sent per file per worker of 2000000 and 5000 per batch.
-INFO:Done. 1275077 were indexed in 2.0712099798663983 minutes. total accumulated time spent in `bulk` indexing: 7.462551590200746 minutes
+```
+Indexing time: 2.07 minutes
+Total accumulated time: 7.46 minutes
+```
 
-## Level 1, Workes, Refresh Interval -1
+## Level 1, Workers
+
+Here it seems that 8 workers are enough. The gains of 16 workers are negligible.
+All of the runs were done with the following defaults:
+```
+Max Docs: 2M
+Batch Size: **3200**
+Refresh Interval: -1
+Full field set, with `bbuy_products` mappings
+```
 
 ### 8
-INFO:Indexing to bbuy_products with 8 workers, refresh_interval of -1 to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
-INFO:Done. 1275077 were indexed in 2.065828593748544 minutes. total accumulated time spent in `bulk` indexing: 7.498947101092199 minutes
+```
+Indexing time: 2.07 minutes
+Total accumulated time: 7.50 minutes
+```
 
 ### 16
-INFO:Indexing to bbuy_products with 16 workers, refresh_interval of -1 to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
-INFO:Done. 1275077 were indexed in 2.055382668750826 minutes. total accumulated time spent in `bulk` indexing: 22.339362691701776 minutes
+```
+Indexing time: 2.06 minutes
+Total accumulated time: 22.34 minutes
+```
 
 ### 32
-INFO:Indexing to bbuy_products with 32 workers, refresh_interval of -1 to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
-INFO:Done. 1275077 were indexed in 2.7611230756990457 minutes. total accumulated time spent in `bulk` indexing: 65.16197838865531 minutes
+```
+Indexing time: 2.76 minutes
+Total accumulated time: 65.16 minutes
+```
 
 ### 64
-INFO:Indexing to bbuy_products with 64 workers, refresh_interval of -1 to host localhost with a maximum number of docs sent per file per worker of 2000000 and 3200 per batch.
-INFO:Done. 1275077 were indexed in 3.1376471444498746 minutes. total accumulated time spent in `bulk` indexing: 156.12936868037988 minutes
+```
+Indexing time: 3.14 minutes
+Total accumulated time: 156.13 minutes
+```
 

--- a/week1/index.py
+++ b/week1/index.py
@@ -29,114 +29,110 @@ mappings = {
     "type":"type/text()",
     "shortDescription": "shortDescription/text()",
     "startDate": "startDate/text()",
-"active": "active/text()",
-"regularPrice": "regularPrice/text()",
-"salePrice": "salePrice/text()",
-"shortDescription": "shortDescription/text()",
-"shortDescriptionHtml": "shortDescriptionHtml/text()",
-"longDescription": "longDescription/text()",
-"longDescriptionHtml": "longDescriptionHtml/text()",
-"artistName": "artistName/text()",
-"onSale": "onSale/text()",
-"digital": "digital/text()",
-"frequentlyPurchasedWith": "frequentlyPurchasedWith/*/text()",  # Note the match all here to get the subfields
-"accessories": "accessories/*/text()" ,  # Note the match all here to get the subfields
-"relatedProducts": "relatedProducts/*/text()",  # Note the match all here to get the subfields
-"crossSell": "crossSell/text()",
-"salesRankShortTerm": "salesRankShortTerm/text()",
-"salesRankMediumTerm": "salesRankMediumTerm/text()",
-"salesRankLongTerm": "salesRankLongTerm/text()",
-"bestSellingRank": "bestSellingRank/text()",
-"url": "url/text()",
-"categoryPath": "categoryPath/*/name/text()",  # Note the match all here to get the subfields
-"categoryPathIds": "categoryPath/*/id/text()",  # Note the match all here to get the subfields
-"categoryLeaf": "categoryPath/category[last()]/id/text()",
-"categoryPathCount": "count(categoryPath/*/name)",
-"customerReviewCount": "customerReviewCount/text()",
-"customerReviewAverage": "customerReviewAverage/text()",
-"inStoreAvailability": "inStoreAvailability/text()",
-"onlineAvailability": "onlineAvailability/text()",
-"releaseDate": "releaseDate/text()",
-"shippingCost": "shippingCost/text()",
-"class": "class/text()",
-"classId": "classId/text()",
-"subclass": "subclass/text()",
-"subclassId": "subclassId/text()",
-"department": "department/text()",
-"departmentId": "departmentId/text()",
-"bestBuyItemId": "bestBuyItemId/text()",
-"description": "description/text()",
-"manufacturer": "manufacturer/text()",
-"modelNumber": "modelNumber/text()",
-"image": "image/text()",
-"condition": "condition/text()",
-"inStorePickup": "inStorePickup/text()",
-"homeDelivery": "homeDelivery/text()",
-"quantityLimit": "quantityLimit/text()",
-"color": "color/text()",
-"depth": "depth/text()",
-"height": "height/text()",
-"weight": "weight/text()",
-"shippingWeight": "shippingWeight/text()",
-"width": "width/text()",
-"features": "features/*/text()"  # Note the match all here to get the subfields
-
+    "active": "active/text()",
+    "regularPrice": "regularPrice/text()",
+    "salePrice": "salePrice/text()",
+    "shortDescription": "shortDescription/text()",
+    "shortDescriptionHtml": "shortDescriptionHtml/text()",
+    "longDescription": "longDescription/text()",
+    "longDescriptionHtml": "longDescriptionHtml/text()",
+    "artistName": "artistName/text()",
+    "onSale": "onSale/text()",
+    "digital": "digital/text()",
+    "frequentlyPurchasedWith": "frequentlyPurchasedWith/*/text()",  # Note the match all here to get the subfields
+    "accessories": "accessories/*/text()" ,  # Note the match all here to get the subfields
+    "relatedProducts": "relatedProducts/*/text()",  # Note the match all here to get the subfields
+    "crossSell": "crossSell/text()",
+    "salesRankShortTerm": "salesRankShortTerm/text()",
+    "salesRankMediumTerm": "salesRankMediumTerm/text()",
+    "salesRankLongTerm": "salesRankLongTerm/text()",
+    "bestSellingRank": "bestSellingRank/text()",
+    "url": "url/text()",
+    "categoryPath": "categoryPath/*/name/text()",  # Note the match all here to get the subfields
+    "categoryPathIds": "categoryPath/*/id/text()",  # Note the match all here to get the subfields
+    "categoryLeaf": "categoryPath/category[last()]/id/text()",
+    "categoryPathCount": "count(categoryPath/*/name)",
+    "customerReviewCount": "customerReviewCount/text()",
+    "customerReviewAverage": "customerReviewAverage/text()",
+    "inStoreAvailability": "inStoreAvailability/text()",
+    "onlineAvailability": "onlineAvailability/text()",
+    "releaseDate": "releaseDate/text()",
+    "shippingCost": "shippingCost/text()",
+    "class": "class/text()",
+    "classId": "classId/text()",
+    "subclass": "subclass/text()",
+    "subclassId": "subclassId/text()",
+    "department": "department/text()",
+    "departmentId": "departmentId/text()",
+    "bestBuyItemId": "bestBuyItemId/text()",
+    "description": "description/text()",
+    "manufacturer": "manufacturer/text()",
+    "modelNumber": "modelNumber/text()",
+    "image": "image/text()",
+    "condition": "condition/text()",
+    "inStorePickup": "inStorePickup/text()",
+    "homeDelivery": "homeDelivery/text()",
+    "quantityLimit": "quantityLimit/text()",
+    "color": "color/text()",
+    "depth": "depth/text()",
+    "height": "height/text()",
+    "weight": "weight/text()",
+    "shippingWeight": "shippingWeight/text()",
+    "width": "width/text()",
+    "features": "features/*/text()",  # Note the match all here to get the subfields
+    "startDate": "startDate/text()",
+    "active": "active/text()",
+    "regularPrice": "regularPrice/text()",
+    "salePrice": "salePrice/text()",
+    "shortDescription": "shortDescription/text()",
+    "shortDescriptionHtml": "shortDescriptionHtml/text()",
+    "longDescription": "longDescription/text()",
+    "longDescriptionHtml": "longDescriptionHtml/text()",
+    "artistName": "artistName/text()",
+    "onSale": "onSale/text()",
+    "digital": "digital/text()",
+    "frequentlyPurchasedWith": "frequentlyPurchasedWith/*/text()",  # Note the match all here to get the subfields
+    "accessories": "accessories/*/text()" ,  # Note the match all here to get the subfields
+    "relatedProducts": "relatedProducts/*/text()",  # Note the match all here to get the subfields
+    "crossSell": "crossSell/text()",
+    "salesRankShortTerm": "salesRankShortTerm/text()",
+    "salesRankMediumTerm": "salesRankMediumTerm/text()",
+    "salesRankLongTerm": "salesRankLongTerm/text()",
+    "bestSellingRank": "bestSellingRank/text()",
+    "url": "url/text()",
+    "categoryPath": "categoryPath/*/name/text()",  # Note the match all here to get the subfields
+    "categoryPathIds": "categoryPath/*/id/text()",  # Note the match all here to get the subfields
+    "categoryLeaf": "categoryPath/category[last()]/id/text()",
+    "categoryPathCount": "count(categoryPath/*/name)",
+    "customerReviewCount": "customerReviewCount/text()",
+    "customerReviewAverage": "customerReviewAverage/text()",
+    "inStoreAvailability": "inStoreAvailability/text()",
+    "onlineAvailability": "onlineAvailability/text()",
+    "releaseDate": "releaseDate/text()",
+    "shippingCost": "shippingCost/text()",
+    "class": "class/text()",
+    "classId": "classId/text()",
+    "subclass": "subclass/text()",
+    "subclassId": "subclassId/text()",
+    "department": "department/text()",
+    "departmentId": "departmentId/text()",
+    "bestBuyItemId": "bestBuyItemId/text()",
+    "description": "description/text()",
+    "manufacturer": "manufacturer/text()",
+    "modelNumber": "modelNumber/text()",
+    "image": "image/text()",
+    "condition": "condition/text()",
+    "inStorePickup": "inStorePickup/text()",
+    "homeDelivery": "homeDelivery/text()",
+    "quantityLimit": "quantityLimit/text()",
+    "color": "color/text()",
+    "depth": "depth/text()",
+    "height": "height/text()",
+    "weight": "weight/text()",
+    "shippingWeight": "shippingWeight/text()",
+    "width": "width/text()",
+    "features": "features/*/text()"  # Note the match all here to get the subfields
 }
-'''
-"startDate": "startDate/text()",
-"active": "active/text()",
-"regularPrice": "regularPrice/text()",
-"salePrice": "salePrice/text()",
-"shortDescription": "shortDescription/text()",
-"shortDescriptionHtml": "shortDescriptionHtml/text()",
-"longDescription": "longDescription/text()",
-"longDescriptionHtml": "longDescriptionHtml/text()",
-"artistName": "artistName/text()",
-"onSale": "onSale/text()",
-"digital": "digital/text()",
-"frequentlyPurchasedWith": "frequentlyPurchasedWith/*/text()",  # Note the match all here to get the subfields
-"accessories": "accessories/*/text()" ,  # Note the match all here to get the subfields
-"relatedProducts": "relatedProducts/*/text()",  # Note the match all here to get the subfields
-"crossSell": "crossSell/text()",
-"salesRankShortTerm": "salesRankShortTerm/text()",
-"salesRankMediumTerm": "salesRankMediumTerm/text()",
-"salesRankLongTerm": "salesRankLongTerm/text()",
-"bestSellingRank": "bestSellingRank/text()",
-"url": "url/text()",
-"categoryPath": "categoryPath/*/name/text()",  # Note the match all here to get the subfields
-"categoryPathIds": "categoryPath/*/id/text()",  # Note the match all here to get the subfields
-"categoryLeaf": "categoryPath/category[last()]/id/text()",
-"categoryPathCount": "count(categoryPath/*/name)",
-"customerReviewCount": "customerReviewCount/text()",
-"customerReviewAverage": "customerReviewAverage/text()",
-"inStoreAvailability": "inStoreAvailability/text()",
-"onlineAvailability": "onlineAvailability/text()",
-"releaseDate": "releaseDate/text()",
-"shippingCost": "shippingCost/text()",
-"class": "class/text()",
-"classId": "classId/text()",
-"subclass": "subclass/text()",
-"subclassId": "subclassId/text()",
-"department": "department/text()",
-"departmentId": "departmentId/text()",
-"bestBuyItemId": "bestBuyItemId/text()",
-"description": "description/text()",
-"manufacturer": "manufacturer/text()",
-"modelNumber": "modelNumber/text()",
-"image": "image/text()",
-"condition": "condition/text()",
-"inStorePickup": "inStorePickup/text()",
-"homeDelivery": "homeDelivery/text()",
-"quantityLimit": "quantityLimit/text()",
-"color": "color/text()",
-"depth": "depth/text()",
-"height": "height/text()",
-"weight": "weight/text()",
-"shippingWeight": "shippingWeight/text()",
-"width": "width/text()",
-"features": "features/*/text()"  # Note the match all here to get the subfields
-
-'''
 
 def get_opensearch(the_host="localhost"):
     host = the_host
@@ -214,7 +210,11 @@ def main(source_dir: str, file_glob: str, index_name: str, workers: int, host: s
 
     client = get_opensearch(host)
 
-    #TODO: set the refresh interval
+    client.indices.put_settings(index=index_name, body={
+        "index": {
+            "refresh_interval": refresh_interval
+        }
+    })
     logger.debug(client.indices.get_settings(index=index_name))
     start = perf_counter()
     time_indexing = 0
@@ -226,8 +226,12 @@ def main(source_dir: str, file_glob: str, index_name: str, workers: int, host: s
             time_indexing += the_time
 
     finish = perf_counter()
-    logger.info(f'Done. {docs_indexed} were indexed in {(finish - start)/60} minutes.  Total accumulated time spent in `bulk` indexing: {time_indexing/60} minutes')
-    # TODO set refresh interval back to 5s
+    logger.info(f'Done. {docs_indexed} were indexed in {(finish - start)/60} minutes.  Total accumulated time spent in `bulk` indexing: {time_indexing/60} minutes\n')
+    client.indices.put_settings(index=index_name, body={
+        "index": {
+            "refresh_interval": "5s"
+        }
+    })
     logger.debug(client.indices.get_settings(index=index_name))
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Week one results

## Level 1, Mappings

Here all as expected:
- Default mappings are analyzed faster than custom ones
- More fields require more processing time

All of the runs were done with the following defaults:

```
Max Docs: 2M
Batch Size: 200
Workers: 8
Refresh Interval: -1
```

### `bbuy_products_no_map` - shorter field set, without user-defined mapping
```
Indexing time: 2.08 minutes
Total accumulated time: 7.78 minutes
```

### `bbuy_products` - shorter field set, instructor mapping
```
Indexing time: 2.24 minutes
Total accumulated time: 8.99 minutes
```

### `bbuy_products_no_map` - full field set, without user-defined mapping
```
Indexing time: 2.13 minutes
Total accumulated time: 8.04 minutes
```

### `bbuy_products` - full field set, instructor mapping
```
Indexing time: 2.27 minutes
Total accumulated time: 9.20 minutes
```

## Level 1, Refresh Interval

Here, surprisingly `60s` interval performed better than switching it off with `-1`.
`1s` is the worst, as expected.
All of the runs were done with the following defaults:

```
Max Docs: 2M
Batch Size: 200
Workers: 8
Full field set, with `bbuy_products` mappings
```

Time | -1 | 1s | 60s
--- | --- | --- | ---
Indexing time (minutes) | 2.13 | 2.27 | 2.10
Total accumulated time (minutes) | 8.24 | 9.28 | 8.06


## Level 1, Batch Size

The best results were at the batch size of 800. At 1600 and 3200 it gets worse. And at 5000 it gets better again, but not as good as 800.
All of the runs were done with the following defaults:
```
Max Docs: 2M
Workers: 8
Refresh Interval: 60s
Full field set, with `bbuy_products` mappings
```

Time | 200 | 400 | 800 | 1600 | 3200 | 5000
--- | --- | --- | --- | --- | --- | ---
Indexing time (minutes) | 2.03 | 2.02 | 2.01 | 2.09 | 2.09 | 2.07
Total accumulated time (minutes) | 7.60 | 7.46 | 7.35 | 7.81 | 7.49 | 7.46


## Level 1, Workers

Here it seems that 8 workers are enough. The gains of 16 workers are negligible.
All of the runs were done with the following defaults:
```
Max Docs: 2M
Batch Size: **3200**
Refresh Interval: -1
Full field set, with `bbuy_products` mappings
```

Time | 8 | 16 | 32 | 64
--- | --- | --- | --- | ---
Indexing time (minutes) | 2.07 | 2.06 | 2.76 | 3.14
Total accumulated time (minutes) | 7.50 | 22.34 | 65.16 | 156.13

## Level 2

As expected, simplifying the query can benefit greatly the speed at the cost of result quality 😅

```
Baseline: 2.45 minutes
No fuzziness: 2.04 minutes
Drop function score: 1.60 minutes
Only multi-match: 1.41 minutes
Multi-match name and short description only: 0.95 minutes
```